### PR TITLE
WF-64705 - Updated the README file for How to set page breaks while exporting WinForms GridControl to pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
-# How-to-set-page-breaks-while-exporting-GridControl-to-pdf
-This example demonstrates how to set page breaks while exporting [GridControl](https://help.syncfusion.com/windowsforms/grid/getting-started?utm_medium=listing&utm_source=github-examples) to PDF.
-See [How to set page breaks while exporting GridControl to pdf?](https://www.syncfusion.com/kb/9635?utm_medium=listing&utm_source=github-examples) for more details.
+# How to set page breaks while exporting WinForms GridControl to pdf
+
+## PDF Exporting
+
+Page breaks can be set while exporting GridControl as PDF by passing row count for each PDF page in the GridPDFConverter.ExportToPdf method. The PDF pages are merged as a single PDF file and saved finally.
+
+## C#
+
+```C#
+private void Exportbutton_Click(object sender, EventArgs e)
+{
+    var converter = new GridPDFConverter();
+    var lowest = 0;
+ 
+    //Adding page breaks to a list.
+    var rows = new List<int> {30, 63, 90, 130, 150};
+ 
+    var pdfDocument = new PdfDocument();
+    pdfDocument.Save("Sample.pdf");
+    foreach (var rownumber in rows)
+    {
+        var pdf = new PdfDocument();
+        var maximumRow = rownumber;
+        converter.ExportToPdf(pdf, gridControl1, GridRangeInfo.Rows(lowest, maximumRow));
+        var stream = new MemoryStream();
+        pdf.Save(stream);
+        var loadedDocument = new PdfLoadedDocument("Sample.pdf");
+        loadedDocument =
+            PdfDocumentBase.Merge(loadedDocument, new PdfLoadedDocument(stream)) as PdfLoadedDocument;
+        loadedDocument.Save("Sample.pdf");
+        loadedDocument.Close(true);
+        stream.Dispose();
+        lowest = maximumRow + 1;
+    }
+    var loadedDocument1 = new PdfLoadedDocument("Sample.pdf");
+    loadedDocument1.Pages.RemoveAt(0);
+    loadedDocument1.Save("Sample.pdf");
+    Process.Start("Sample.pdf");
+}
+```


### PR DESCRIPTION
Modify the ReadMe files in KB's example sample
https://syncfusion.atlassian.net/browse/WF-64705

I have updated the content in the ReadMe file with the content of the below KB document, https://www.syncfusion.com/kb/9635/how-to-set-page-breaks-while-exporting-winforms-gridcontrol-to-pdf 